### PR TITLE
Change expected binary name to kubelogin

### DIFF
--- a/kubelogin.rb
+++ b/kubelogin.rb
@@ -5,7 +5,7 @@ class Kubelogin < Formula
   version "v1.9.1"
   sha256 "757c6bcc997fb3146b40de8b3633e51a78dd42c45f6242e0f5bae488e16fee2f"
   def install
-    bin.install "kubelogin_darwin_amd64" => "kubelogin"
+    bin.install "kubelogin" => "kubelogin"
     ln_s bin/"kubelogin", bin/"kubectl-oidc_login"
   end
   test do


### PR DESCRIPTION
This fixes a homebrew installation failure since version 1.8.2.