### PR TITLE
Add deprecated notice for kubelogin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+## Deprecated notice :warning:
+
+Use https://formulae.brew.sh/formula/kubelogin instead.
+
+----
+
+## Getting Started
+
 To install [kubelogin](https://github.com/int128/kubelogin):
 
 ```sh


### PR DESCRIPTION
Added a deprecated notice and alternative link for kubelogin.